### PR TITLE
Adding support for compiling/deploying the TimeWindowCompactionStrategy library

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,6 +29,7 @@ platforms:
   - name: centos-7.2
     run_list:
     - recipe[yum]
+  - name: mvbcoding/awslinux
 
 suites:
   - name: default
@@ -117,3 +118,11 @@ suites:
             databag: false
             username: <%= ENV['CASSANDRA_DSE_USERNAME'] %>
             password: <%= ENV['CASSANDRA_DSE_PASSWORD'] %>
+
+  - name: twcs
+    run_list:
+      - recipe[cassandra-dse::twcs]
+    attributes:
+      cassandra:
+        user: vagrant
+        group: vagrant

--- a/attributes/twcs.rb
+++ b/attributes/twcs.rb
@@ -1,0 +1,8 @@
+# Override the default (7) set in attributes/default
+force_default['java']['jdk_version'] = 8
+
+default['cassandra']['twcs']['base_version'] = node['cassandra']['version'].split('.')[0...-1].join('.')
+default['cassandra']['twcs']['src_path'] = '/tmp/twcs-repo'
+default['cassandra']['twcs']['repo_url'] = 'https://github.com/jeffjirsa/twcs.git'
+default['cassandra']['twcs']['revision'] = "cassandra-#{node['cassandra']['twcs']['base_version']}"
+default['cassandra']['twcs']['target_lib_path'] = '/usr/share/cassandra/lib'

--- a/attributes/twcs.rb
+++ b/attributes/twcs.rb
@@ -1,5 +1,7 @@
 # Override the default (7) set in attributes/default
 force_default['java']['jdk_version'] = 8
+# Override the default (2) set by the upstream maven cookbook
+force_default['maven']['version'] = '3'
 
 default['cassandra']['twcs']['base_version'] = node['cassandra']['version'].split('.')[0...-1].join('.')
 default['cassandra']['twcs']['src_path'] = '/tmp/twcs-repo'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,14 @@ description 'Installs/configures Apache Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/michaelklishin/cassandra-chef-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/michaelklishin/cassandra-chef-cookbook/issues' if respond_to?(:issues_url)
-version '4.3.0'
+version '4.4.0'
 depends 'java'
 depends 'ulimit'
 depends 'apt'
 depends 'yum'
 depends 'ark'
+depends 'maven'
+depends 'git'
 
 %w(ubuntu centos redhat fedora amazon).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/configures Apache Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/michaelklishin/cassandra-chef-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/michaelklishin/cassandra-chef-cookbook/issues' if respond_to?(:issues_url)
-version '4.2.1'
+version '4.3.0'
 depends 'java'
 depends 'ulimit'
 depends 'apt'

--- a/recipes/claim_dirs.rb
+++ b/recipes/claim_dirs.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: cassandra-dse
+# Recipe:: claim_dirs
+#
+# Copyright 2017 Apptentive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Grab all the directories defined by the cookbook
+dirs = node['cassandra']['data_dir'].dup
+%w( commitlog saved_caches ).each do |dir|
+  dir += '_dir'
+  dirs << node['cassandra'][dir] if (node['cassandra'].has_key?(dir) && !dirs.include?(node['cassandra'][dir]))
+end
+
+# Grab the directories defined within cassandra.yaml
+%w( commitlog hints saved_caches ).each do |dir|
+  dir += '_directory'
+  dirs << node['cassandra']['config'][dir] if (node['cassandra']['config'].has_key?(dir) && !dirs.include?(node['cassandra']['config'][dir]))
+end
+
+# Skip the directories that are children of the root directory
+# (they already get chowned)
+dirs.delete_if do |dir|
+  root_dir = node['cassandra']['root_dir']
+  dir[0...root_dir.size] == root_dir && (dir.size == root_dir.size || dir[root_dir.size] == ?/)
+end
+
+dirs.each do |dir|
+  directory dir do
+    user node['cassandra']['user']
+    group node['cassandra']['group']
+  end
+end

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -57,6 +57,7 @@ node.default['cassandra']['commitlog_dir'] = ::File.join(node['cassandra']['root
 node.default['cassandra']['saved_caches_dir'] = ::File.join(node['cassandra']['root_dir'], 'saved_caches')
 
 include_recipe 'cassandra-dse::user'
+include_recipe 'cassandra-dse::claim_dirs'
 include_recipe 'cassandra-dse::repositories'
 
 # setup repository and install datastax C* packages

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -39,6 +39,9 @@ node.default['cassandra']['saved_caches_dir'] = ::File.join(node['cassandra']['r
 # manage C* service user
 include_recipe 'cassandra-dse::user'
 
+# claim ownership of data dirs if needed
+include_recipe 'cassandra-dse::claim_dirs'
+
 require 'tmpdir'
 
 td = Dir.tmpdir

--- a/recipes/twcs.rb
+++ b/recipes/twcs.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook Name:: cassandra-dse
+# Recipe:: twcs
+#
+# Copyright 2017 Apptentive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cassandra = node['cassandra']
+twcs = cassandra['twcs']
+
+include_recipe 'git::default'
+
+directory twcs['src_path'] do
+  recursive true
+end
+
+git twcs['src_path'] do
+  repository twcs['repo_url']
+  revision twcs['revision']
+  action :sync
+end
+
+include_recipe 'java' if cassandra['install_java']
+
+include_recipe 'maven::default'
+
+bash 'compile TWCS plugin' do
+  cwd twcs['src_path']
+  code 'mvn compile && mvn package'
+  environment ({ "JAVA_HOME" => node[:java][:java_home] })
+end
+
+directory twcs['target_lib_path'] do
+  recursive true
+  user cassandra['user']
+  group cassandra['group']
+  mode 0755
+end
+
+ruby_block 'install TWCS' do
+  block do
+    find_jar_glob = File::join(twcs['src_path'], 'target', "TimeWindowCompactionStrategy-#{cassandra['base_version']}*.jar")
+    compiled_jar = Dir.glob(find_jar_glob).first
+    jar_target = File::join(twcs['target_lib_path'], File::basename(compiled_jar))
+
+    FileUtils.mv(compiled_jar, jar_target)
+    FileUtils.chown(cassandra['user'], cassandra['group'], jar_target)
+  end
+end

--- a/recipes/twcs.rb
+++ b/recipes/twcs.rb
@@ -19,43 +19,47 @@
 
 cassandra = node['cassandra']
 twcs = cassandra['twcs']
+jar_glob = "TimeWindowCompactionStrategy-#{twcs['base_version']}.*.jar"
 
-include_recipe 'git::default'
+# Skip if the jar already exists
+if Dir.glob(File::join(twcs['target_lib_path'], jar_glob)).empty?
+  include_recipe 'git::default'
 
-directory twcs['src_path'] do
-  recursive true
-end
+  directory twcs['src_path'] do
+    recursive true
+  end
 
-git twcs['src_path'] do
-  repository twcs['repo_url']
-  revision twcs['revision']
-  action :sync
-end
+  git twcs['src_path'] do
+    repository twcs['repo_url']
+    revision twcs['revision']
+    action :sync
+  end
 
-include_recipe 'java' if cassandra['install_java']
+  include_recipe 'java' if cassandra['install_java']
 
-include_recipe 'maven::default'
+  include_recipe 'maven::default'
 
-bash 'compile TWCS plugin' do
-  cwd twcs['src_path']
-  code 'mvn compile && mvn package'
-  environment ({ "JAVA_HOME" => node[:java][:java_home] })
-end
+  bash 'compile TWCS plugin' do
+    cwd twcs['src_path']
+    code 'mvn compile && mvn package'
+    environment ({ "JAVA_HOME" => node[:java][:java_home] })
+  end
 
-directory twcs['target_lib_path'] do
-  recursive true
-  user cassandra['user']
-  group cassandra['group']
-  mode 0755
-end
+  directory twcs['target_lib_path'] do
+    recursive true
+    user cassandra['user']
+    group cassandra['group']
+    mode 0755
+  end
 
-ruby_block 'install TWCS' do
-  block do
-    find_jar_glob = File::join(twcs['src_path'], 'target', "TimeWindowCompactionStrategy-#{cassandra['base_version']}*.jar")
-    compiled_jar = Dir.glob(find_jar_glob).first
-    jar_target = File::join(twcs['target_lib_path'], File::basename(compiled_jar))
+  ruby_block 'install TWCS' do
+    block do
+      compiled_jar = Dir.glob(File::join(twcs['src_path'], 'target', jar_glob)).first
+      jar_target = File::join(twcs['target_lib_path'], File::basename(compiled_jar))
 
-    FileUtils.mv(compiled_jar, jar_target)
-    FileUtils.chown(cassandra['user'], cassandra['group'], jar_target)
+      FileUtils.mv(compiled_jar, jar_target)
+      FileUtils.chown(cassandra['user'], cassandra['group'], jar_target)
+      FileUtils.chmod(0755, jar_target)
+    end
   end
 end

--- a/test/integration/twcs/serverspec/twcs_spec.rb
+++ b/test/integration/twcs/serverspec/twcs_spec.rb
@@ -1,23 +1,8 @@
 require 'spec_helper'
 
-describe package('git') do
-  it { should be_installed }
-end
-
-describe file('/tmp/twcs-repo') do
-  it { should be_directory }
-end
-
-describe file('/usr/local/maven') do
-  it { should be_symlink }
-end
-
-describe file('/usr/share/cassandra/lib') do
-  it { should be_directory }
-end
-
 describe file('/usr/share/cassandra/lib/TimeWindowCompactionStrategy-2.2.5.jar') do
   it { should be_file }
   it { should be_owned_by 'vagrant' }
   it { should be_grouped_into 'vagrant' }
+  it { should be_mode 755 }
 end

--- a/test/integration/twcs/serverspec/twcs_spec.rb
+++ b/test/integration/twcs/serverspec/twcs_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe package('git') do
+  it { should be_installed }
+end
+
+describe file('/tmp/twcs-repo') do
+  it { should be_directory }
+end
+
+describe file('/usr/local/maven') do
+  it { should be_symlink }
+end
+
+describe file('/usr/share/cassandra/lib') do
+  it { should be_directory }
+end
+
+describe file('/usr/share/cassandra/lib/TimeWindowCompactionStrategy-2.2.5.jar') do
+  it { should be_file }
+  it { should be_owned_by 'vagrant' }
+  it { should be_grouped_into 'vagrant' }
+end


### PR DESCRIPTION
This branches from https://github.com/apptentive-engineering/cassandra-chef-cookbook/pull/4, so you might want to approve/merge that one first.